### PR TITLE
Fix issue with contribution displayed as 0

### DIFF
--- a/src/components/Resume/Repositories.js
+++ b/src/components/Resume/Repositories.js
@@ -15,7 +15,7 @@ function Repositories({ repoList, username, titleColor }) {
     },
   } = useContext(ConfigContext);
 
-  if (!count) return null;
+  if (!count || !repoList?.length) return null;
 
   return (
     <Wrapper>

--- a/src/components/Resume/Resume.js
+++ b/src/components/Resume/Resume.js
@@ -79,7 +79,7 @@ function Resume({ titleColor }) {
         username={username}
         titleColor={titleColor}
       />
-      {data.user.contributionsCollection.totalPullRequestContributions && (
+      {data.user.contributionsCollection.totalPullRequestContributions > 0 && (
         <Contributions
           repoList={data.user.contributionsCollection.pullRequestContributionsByRepository}
           titleColor={titleColor}


### PR DESCRIPTION
If no contributions have been made in the last year, the section is now skipped. (previously it was showing 0)

Issue: https://github.com/Satyam1203/resume-github/issues/9

![image](https://github.com/user-attachments/assets/79bebd63-e5d0-40c4-936f-cb58ed9c4cf9)
